### PR TITLE
#51 Remove client dependency in entity factories.

### DIFF
--- a/client_core/src/com/mygdx/game/client_core/network/comp_handlers/EntityConfigHandler.java
+++ b/client_core/src/com/mygdx/game/client_core/network/comp_handlers/EntityConfigHandler.java
@@ -12,7 +12,6 @@ import com.mygdx.game.config.FieldConfig;
 import com.mygdx.game.config.GameConfigs;
 import com.mygdx.game.config.SubFieldConfig;
 import com.mygdx.game.config.TechnologyConfig;
-import com.mygdx.game.config.TextureConfig;
 import com.mygdx.game.config.UnitConfig;
 import com.mygdx.game.core.ecs.component.EntityConfigId;
 import lombok.extern.java.Log;

--- a/core/src/com/mygdx/game/core/ecs/component/Field.java
+++ b/core/src/com/mygdx/game/core/ecs/component/Field.java
@@ -1,6 +1,7 @@
 package com.mygdx.game.core.ecs.component;
 
 import com.artemis.PooledComponent;
+import com.artemis.annotations.EntityId;
 import com.badlogic.gdx.utils.IntArray;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,7 @@ import lombok.NonNull;
 @NoArgsConstructor
 public class Field extends PooledComponent {
 
-  private @NonNull IntArray subFields = new IntArray();
+  private @NonNull @EntityId IntArray subFields = new IntArray();
 
   @Override
   protected void reset() {

--- a/core/src/com/mygdx/game/core/ecs/component/Technology.java
+++ b/core/src/com/mygdx/game/core/ecs/component/Technology.java
@@ -2,7 +2,6 @@ package com.mygdx.game.core.ecs.component;
 
 import com.artemis.PooledComponent;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
 public class Technology extends PooledComponent {

--- a/desktop/src/com/mygdx/game/client/input/TechnologyScreenUiInputAdapter.java
+++ b/desktop/src/com/mygdx/game/client/input/TechnologyScreenUiInputAdapter.java
@@ -2,7 +2,6 @@ package com.mygdx.game.client.input;
 
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
-import com.mygdx.game.client.GdxGame;
 import com.mygdx.game.client.screen.Navigator;
 import lombok.NonNull;
 

--- a/desktop/src/com/mygdx/game/client/screen/GameScreen.java
+++ b/desktop/src/com/mygdx/game/client/screen/GameScreen.java
@@ -7,7 +7,6 @@ import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.Viewport;
-import com.mygdx.game.client.GdxGame;
 import com.mygdx.game.client.ModelInstanceRenderer;
 import com.mygdx.game.client.di.StageModule;
 import com.mygdx.game.client.input.CameraMoverInputProcessor;

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/ComponentFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/ComponentFactory.java
@@ -2,7 +2,9 @@ package com.mygdx.game.server.ecs.entityfactory;
 
 import com.artemis.ComponentMapper;
 import com.artemis.World;
+import com.mygdx.game.config.EntityConfig;
 import com.mygdx.game.core.ecs.component.Coordinates;
+import com.mygdx.game.core.ecs.component.EntityConfigId;
 import com.mygdx.game.core.ecs.component.SubField;
 import com.mygdx.game.server.network.GameRoomSyncer;
 import lombok.NonNull;
@@ -20,6 +22,7 @@ public class ComponentFactory {
 
   private final ComponentMapper<SubField> subFieldMapper;
   private final ComponentMapper<Coordinates> coordinatesMapper;
+  private final ComponentMapper<EntityConfigId> entityConfigIdMapper;
 
   @Inject
   public ComponentFactory(
@@ -31,6 +34,7 @@ public class ComponentFactory {
 
     this.subFieldMapper = world.getMapper(SubField.class);
     this.coordinatesMapper = world.getMapper(Coordinates.class);
+    this.entityConfigIdMapper = world.getMapper(EntityConfigId.class);
   }
 
   public int createEntityId() {
@@ -47,5 +51,12 @@ public class ComponentFactory {
     var subField = subFieldMapper.create(entityId);
     subField.setParent(fieldId);
     syncer.sendComponent(subField, entityId);
+  }
+
+  public void setUpEntityConfig(@NonNull EntityConfig config, int entityId) {
+    int configId = config.getId();
+    var entityConfigIdComponent = entityConfigIdMapper.create(entityId);
+    entityConfigIdComponent.setId(configId);
+    syncer.sendComponent(entityConfigIdComponent, entityId);
   }
 }

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/EntityFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/EntityFactory.java
@@ -1,21 +1,10 @@
 package com.mygdx.game.server.ecs.entityfactory;
 
-import com.artemis.World;
-import com.mygdx.game.assets.GameConfigAssets;
 import com.mygdx.game.config.EntityConfig;
 import lombok.NonNull;
 
-public abstract class EntityFactory<T extends EntityConfig> {
+public interface EntityFactory<T extends EntityConfig> {
 
-  protected final World world;
-  protected final GameConfigAssets assets;
-
-  protected EntityFactory(World world, GameConfigAssets assets) {
-    this.world = world;
-    this.assets = assets;
-  }
-
-  @NonNull
-  public abstract void createEntity(int entityId, T entityConfig);
+  @NonNull void createEntity(int entityId, T entityConfig);
 
 }

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/EntityFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/EntityFactory.java
@@ -3,8 +3,6 @@ package com.mygdx.game.server.ecs.entityfactory;
 import com.artemis.World;
 import com.mygdx.game.assets.GameConfigAssets;
 import com.mygdx.game.config.EntityConfig;
-import com.mygdx.game.core.ecs.component.Coordinates;
-import com.mygdx.game.server.model.Client;
 import lombok.NonNull;
 
 public abstract class EntityFactory<T extends EntityConfig> {
@@ -18,6 +16,6 @@ public abstract class EntityFactory<T extends EntityConfig> {
   }
 
   @NonNull
-  public abstract void createEntity(int entityId, T entityConfig, Client client);
+  public abstract void createEntity(int entityId, T entityConfig);
 
 }

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/FieldFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/FieldFactory.java
@@ -2,10 +2,7 @@ package com.mygdx.game.server.ecs.entityfactory;
 
 import com.artemis.ComponentMapper;
 import com.artemis.World;
-import com.mygdx.game.assets.GameConfigAssets;
 import com.mygdx.game.config.FieldConfig;
-import com.mygdx.game.core.ecs.component.Coordinates;
-import com.mygdx.game.core.ecs.component.EntityConfigId;
 import com.mygdx.game.core.ecs.component.Field;
 import com.mygdx.game.server.initialize.SubfieldMapInitializer;
 import com.mygdx.game.server.network.GameRoomSyncer;
@@ -17,49 +14,36 @@ import javax.inject.Singleton;
 
 @Singleton
 @Log
-public class FieldFactory extends EntityFactory<FieldConfig> {
+public class FieldFactory implements EntityFactory<FieldConfig> {
 
-  private final ComponentMapper<Coordinates> coordinatesMapper;
-  private final ComponentMapper<EntityConfigId> entityConfigIdMapper;
   private final ComponentMapper<Field> fieldMapper;
   private final GameRoomSyncer syncer;
   private final SubfieldMapInitializer subMapInitializer;
+  private final ComponentFactory componentFactory;
 
   @Inject
   public FieldFactory(
       @NonNull World world,
-      @NonNull GameConfigAssets assets,
       @NonNull GameRoomSyncer gameRoomSyncer,
-      @NonNull SubfieldMapInitializer subMapInitializer
+      @NonNull SubfieldMapInitializer subMapInitializer,
+      @NonNull ComponentFactory componentFactory
   ) {
-    super(world, assets);
-    this.coordinatesMapper = world.getMapper(Coordinates.class);
-    this.entityConfigIdMapper = world.getMapper(EntityConfigId.class);
     this.fieldMapper = world.getMapper(Field.class);
     this.syncer = gameRoomSyncer;
     this.subMapInitializer = subMapInitializer;
+    this.componentFactory = componentFactory;
   }
 
   @Override
   public void createEntity(int entityId, @NonNull FieldConfig config) {
-    var entityConfigId = setUpEntityConfig(config, entityId);
-    var fieldComponent = setUpField(entityId);
-
-    syncer.sendComponent(entityConfigId, entityId);
-    syncer.sendComponent(fieldComponent, entityId);
+    componentFactory.setUpEntityConfig(config, entityId);
+    setUpField(entityId);
   }
 
-  private EntityConfigId setUpEntityConfig(@NonNull FieldConfig config, int entityId) {
-    var entityConfigId = config.getId();
-    var entityConfigIdComponent = entityConfigIdMapper.create(entityId);
-    entityConfigIdComponent.setId(entityConfigId);
-    return entityConfigIdComponent;
-  }
-
-  private Field setUpField(int entityId) {
+  private void setUpField(int entityId) {
     var field = fieldMapper.create(entityId);
     var subFields = subMapInitializer.initializeSubarea(entityId);
     field.setSubFields(subFields);
-    return field;
+    syncer.sendComponent(field, entityId);
   }
 }

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/FieldFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/FieldFactory.java
@@ -8,7 +8,6 @@ import com.mygdx.game.core.ecs.component.Coordinates;
 import com.mygdx.game.core.ecs.component.EntityConfigId;
 import com.mygdx.game.core.ecs.component.Field;
 import com.mygdx.game.server.initialize.SubfieldMapInitializer;
-import com.mygdx.game.server.model.Client;
 import com.mygdx.game.server.network.GameRoomSyncer;
 import lombok.NonNull;
 import lombok.extern.java.Log;
@@ -42,9 +41,9 @@ public class FieldFactory extends EntityFactory<FieldConfig> {
   }
 
   @Override
-  public void createEntity(int entityId, @NonNull FieldConfig config, Client clientOwner) {
+  public void createEntity(int entityId, @NonNull FieldConfig config) {
     var entityConfigId = setUpEntityConfig(config, entityId);
-    var fieldComponent = setUpField(entityId, clientOwner);
+    var fieldComponent = setUpField(entityId);
 
     syncer.sendComponent(entityConfigId, entityId);
     syncer.sendComponent(fieldComponent, entityId);
@@ -57,9 +56,9 @@ public class FieldFactory extends EntityFactory<FieldConfig> {
     return entityConfigIdComponent;
   }
 
-  private Field setUpField(int entityId, Client clientOwner) {
+  private Field setUpField(int entityId) {
     var field = fieldMapper.create(entityId);
-    var subFields = subMapInitializer.initializeSubarea(entityId, clientOwner);
+    var subFields = subMapInitializer.initializeSubarea(entityId);
     field.setSubFields(subFields);
     return field;
   }

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/SubFieldFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/SubFieldFactory.java
@@ -5,7 +5,6 @@ import com.artemis.World;
 import com.mygdx.game.assets.GameConfigAssets;
 import com.mygdx.game.config.SubFieldConfig;
 import com.mygdx.game.core.ecs.component.EntityConfigId;
-import com.mygdx.game.server.model.Client;
 import com.mygdx.game.server.network.GameRoomSyncer;
 import lombok.NonNull;
 import lombok.extern.java.Log;
@@ -32,7 +31,7 @@ public class SubFieldFactory extends EntityFactory<SubFieldConfig> {
   }
 
   @Override
-  public void createEntity(int entityId, @NonNull SubFieldConfig config, Client clientOwner) {
+  public void createEntity(int entityId, @NonNull SubFieldConfig config) {
     var entityConfigId = setUpEntityConfig(config, entityId);
     syncer.sendComponent(entityConfigId, entityId);
   }

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/SubFieldFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/SubFieldFactory.java
@@ -1,11 +1,6 @@
 package com.mygdx.game.server.ecs.entityfactory;
 
-import com.artemis.ComponentMapper;
-import com.artemis.World;
-import com.mygdx.game.assets.GameConfigAssets;
 import com.mygdx.game.config.SubFieldConfig;
-import com.mygdx.game.core.ecs.component.EntityConfigId;
-import com.mygdx.game.server.network.GameRoomSyncer;
 import lombok.NonNull;
 import lombok.extern.java.Log;
 
@@ -14,33 +9,20 @@ import javax.inject.Singleton;
 
 @Singleton
 @Log
-public class SubFieldFactory extends EntityFactory<SubFieldConfig> {
+public class SubFieldFactory implements EntityFactory<SubFieldConfig> {
 
-  private final ComponentMapper<EntityConfigId> entityConfigIdMapper;
-  private final GameRoomSyncer syncer;
+  private final ComponentFactory componentFactory;
 
   @Inject
   public SubFieldFactory(
-      @NonNull World world,
-      @NonNull GameConfigAssets assets,
-      @NonNull GameRoomSyncer gameRoomSyncer
+      @NonNull ComponentFactory componentFactory
   ) {
-    super(world, assets);
-    this.entityConfigIdMapper = world.getMapper(EntityConfigId.class);
-    this.syncer = gameRoomSyncer;
+    this.componentFactory = componentFactory;
   }
 
   @Override
   public void createEntity(int entityId, @NonNull SubFieldConfig config) {
-    var entityConfigId = setUpEntityConfig(config, entityId);
-    syncer.sendComponent(entityConfigId, entityId);
-  }
-
-  private EntityConfigId setUpEntityConfig(@NonNull SubFieldConfig config, int entityId) {
-    var entityConfigId = config.getId();
-    var entityConfigIdComponent = entityConfigIdMapper.create(entityId);
-    entityConfigIdComponent.setId(entityConfigId);
-    return entityConfigIdComponent;
+    componentFactory.setUpEntityConfig(config, entityId);
   }
 
 }

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/TechnologyFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/TechnologyFactory.java
@@ -3,12 +3,9 @@ package com.mygdx.game.server.ecs.entityfactory;
 import com.artemis.ComponentMapper;
 import com.artemis.World;
 import com.mygdx.game.assets.GameConfigAssets;
-import com.mygdx.game.config.SubFieldConfig;
 import com.mygdx.game.config.TechnologyConfig;
-import com.mygdx.game.core.ecs.component.Coordinates;
 import com.mygdx.game.core.ecs.component.EntityConfigId;
 import com.mygdx.game.core.ecs.component.Technology;
-import com.mygdx.game.server.model.Client;
 import com.mygdx.game.server.network.GameRoomSyncer;
 import lombok.NonNull;
 import lombok.extern.java.Log;
@@ -37,7 +34,7 @@ public class TechnologyFactory extends EntityFactory<TechnologyConfig> {
   }
 
   @Override
-  public void createEntity(int entityId, @NonNull TechnologyConfig config, Client client) {
+  public void createEntity(int entityId, @NonNull TechnologyConfig config) {
     var entityConfigId = setUpEntityConfig(config, entityId);
     syncer.sendComponent(entityConfigId, entityId);
 

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/TechnologyFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/TechnologyFactory.java
@@ -1,12 +1,6 @@
 package com.mygdx.game.server.ecs.entityfactory;
 
-import com.artemis.ComponentMapper;
-import com.artemis.World;
-import com.mygdx.game.assets.GameConfigAssets;
 import com.mygdx.game.config.TechnologyConfig;
-import com.mygdx.game.core.ecs.component.EntityConfigId;
-import com.mygdx.game.core.ecs.component.Technology;
-import com.mygdx.game.server.network.GameRoomSyncer;
 import lombok.NonNull;
 import lombok.extern.java.Log;
 
@@ -15,36 +9,20 @@ import javax.inject.Singleton;
 
 @Singleton
 @Log
-public class TechnologyFactory extends EntityFactory<TechnologyConfig> {
+public class TechnologyFactory implements EntityFactory<TechnologyConfig> {
 
-  private final ComponentMapper<EntityConfigId> entityConfigIdMapper;
-  private final ComponentMapper<Technology> technologyMapper;
-  private final GameRoomSyncer syncer;
+  private final ComponentFactory componentFactory;
 
   @Inject
   public TechnologyFactory(
-      @NonNull World world,
-      @NonNull GameConfigAssets assets,
-      @NonNull GameRoomSyncer syncer
+      @NonNull ComponentFactory componentFactory
   ) {
-    super(world, assets);
-    this.entityConfigIdMapper = world.getMapper(EntityConfigId.class);
-    this.technologyMapper = world.getMapper(Technology.class);
-    this.syncer = syncer;
+    this.componentFactory = componentFactory;
   }
 
   @Override
   public void createEntity(int entityId, @NonNull TechnologyConfig config) {
-    var entityConfigId = setUpEntityConfig(config, entityId);
-    syncer.sendComponent(entityConfigId, entityId);
-
-  }
-
-  private EntityConfigId setUpEntityConfig(@NonNull TechnologyConfig config, int entityId) {
-    int configId = config.getId();
-    var entityConfigIdComponent = entityConfigIdMapper.create(entityId);
-    entityConfigIdComponent.setId(configId);
-    return entityConfigIdComponent;
+    componentFactory.setUpEntityConfig(config, entityId);
   }
 
 }

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/UnitFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/UnitFactory.java
@@ -6,7 +6,6 @@ import com.mygdx.game.assets.GameConfigAssets;
 import com.mygdx.game.config.UnitConfig;
 import com.mygdx.game.core.ecs.component.Coordinates;
 import com.mygdx.game.core.ecs.component.EntityConfigId;
-import com.mygdx.game.server.model.Client;
 import com.mygdx.game.server.network.GameRoomSyncer;
 import lombok.NonNull;
 import lombok.extern.java.Log;
@@ -35,7 +34,7 @@ public class UnitFactory extends EntityFactory<UnitConfig> {
   }
 
   @Override
-  public void createEntity(int entityId, @NonNull UnitConfig config, Client client) {
+  public void createEntity(int entityId, @NonNull UnitConfig config) {
     var entityConfigId = setUpEntityConfig(entityId);
 
     syncer.sendComponent(entityConfigId, entityId);

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/UnitFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/UnitFactory.java
@@ -1,12 +1,6 @@
 package com.mygdx.game.server.ecs.entityfactory;
 
-import com.artemis.ComponentMapper;
-import com.artemis.World;
-import com.mygdx.game.assets.GameConfigAssets;
 import com.mygdx.game.config.UnitConfig;
-import com.mygdx.game.core.ecs.component.Coordinates;
-import com.mygdx.game.core.ecs.component.EntityConfigId;
-import com.mygdx.game.server.network.GameRoomSyncer;
 import lombok.NonNull;
 import lombok.extern.java.Log;
 
@@ -15,36 +9,20 @@ import javax.inject.Singleton;
 
 @Singleton
 @Log
-public class UnitFactory extends EntityFactory<UnitConfig> {
+public class UnitFactory implements EntityFactory<UnitConfig> {
 
-  private final ComponentMapper<Coordinates> coordinatesMapper;
-  private final ComponentMapper<EntityConfigId> entityConfigIdMapper;
-  private final GameRoomSyncer syncer;
+  private final ComponentFactory componentFactory;
 
   @Inject
   public UnitFactory(
-      @NonNull World world,
-      @NonNull GameConfigAssets assets,
-      @NonNull GameRoomSyncer syncer
+      @NonNull ComponentFactory componentFactory
   ) {
-    super(world, assets);
-    this.coordinatesMapper = world.getMapper(Coordinates.class);
-    this.entityConfigIdMapper = world.getMapper(EntityConfigId.class);
-    this.syncer = syncer;
+    this.componentFactory = componentFactory;
   }
 
   @Override
   public void createEntity(int entityId, @NonNull UnitConfig config) {
-    var entityConfigId = setUpEntityConfig(entityId);
-
-    syncer.sendComponent(entityConfigId, entityId);
-  }
-
-  private EntityConfigId setUpEntityConfig(int entityId) {
-    var entityConfigId = assets.getGameConfigs().getAny(UnitConfig.class).getId();
-    var entityConfigIdComponent = entityConfigIdMapper.create(entityId);
-    entityConfigIdComponent.setId(entityConfigId);
-    return entityConfigIdComponent;
+    componentFactory.setUpEntityConfig(config, entityId);
   }
 
 }

--- a/desktop_server/src/com/mygdx/game/server/initialize/MapInitializer.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/MapInitializer.java
@@ -6,7 +6,6 @@ import com.mygdx.game.config.GameConfigs;
 import com.mygdx.game.core.ecs.component.Coordinates;
 import com.mygdx.game.server.ecs.entityfactory.ComponentFactory;
 import com.mygdx.game.server.ecs.entityfactory.FieldFactory;
-import com.mygdx.game.server.model.Client;
 import lombok.NonNull;
 
 import javax.inject.Inject;
@@ -35,11 +34,11 @@ public class MapInitializer {
     this.assets = assets;
   }
 
-  public void initializeMap(Client owner) {
-    initializeMap(INITIAL_WIDTH, INITIAL_HEIGHT, owner);
+  public void initializeMap() {
+    initializeMap(INITIAL_WIDTH, INITIAL_HEIGHT);
   }
 
-  public void initializeMap(int width, int height, Client owner) {
+  public void initializeMap(int width, int height) {
     if (initialized) {
       return;
     } else {
@@ -53,18 +52,17 @@ public class MapInitializer {
           var config = assets
               .getGameConfigs()
               .get(FieldConfig.class, random.nextInt(GameConfigs.FIELD_MIN, GameConfigs.FIELD_MAX));
-          fieldFactory.createEntity(entityId, config, owner);
+          fieldFactory.createEntity(entityId, config);
         }
       }
     }
-    createWinningField(owner);
+    createWinningField();
   }
 
-  private void createWinningField(Client owner) {
+  private void createWinningField() {
     var winningConfig = assets.getGameConfigs().get(FieldConfig.class, 5);
-
     int entityId = componentFactory.createEntityId();
     componentFactory.createCoordinateComponent(new Coordinates(4, 4), entityId);
-    fieldFactory.createEntity(entityId, winningConfig, owner);
+    fieldFactory.createEntity(entityId, winningConfig);
   }
 }

--- a/desktop_server/src/com/mygdx/game/server/initialize/StartUnitInitializer.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/StartUnitInitializer.java
@@ -6,7 +6,6 @@ import com.mygdx.game.config.UnitConfig;
 import com.mygdx.game.core.ecs.component.Coordinates;
 import com.mygdx.game.server.ecs.entityfactory.ComponentFactory;
 import com.mygdx.game.server.ecs.entityfactory.UnitFactory;
-import com.mygdx.game.server.model.Client;
 import lombok.NonNull;
 
 import javax.inject.Inject;
@@ -31,7 +30,7 @@ public class StartUnitInitializer {
     this.assets = assets;
   }
 
-  public void initializeTestUnit(Client owner) {
+  public void initializeTestUnit() {
     if (initialized) {
       return;
     } else {
@@ -40,6 +39,6 @@ public class StartUnitInitializer {
     int entityId = componentFactory.createEntityId();
     componentFactory.createCoordinateComponent(new Coordinates(0, 0), entityId);
     var anyConfig = assets.getGameConfigs().get(UnitConfig.class, random.nextInt(GameConfigs.UNIT_MAX - GameConfigs.UNIT_MIN) + GameConfigs.UNIT_MIN);
-    unitFactory.createEntity(entityId, anyConfig, owner);
+    unitFactory.createEntity(entityId, anyConfig);
   }
 }

--- a/desktop_server/src/com/mygdx/game/server/initialize/SubfieldMapInitializer.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/SubfieldMapInitializer.java
@@ -1,17 +1,12 @@
 package com.mygdx.game.server.initialize;
 
-import com.artemis.ComponentMapper;
-import com.artemis.World;
 import com.badlogic.gdx.utils.IntArray;
 import com.mygdx.game.assets.GameConfigAssets;
 import com.mygdx.game.config.GameConfigs;
 import com.mygdx.game.config.SubFieldConfig;
 import com.mygdx.game.core.ecs.component.Coordinates;
-import com.mygdx.game.core.ecs.component.SubField;
 import com.mygdx.game.server.ecs.entityfactory.ComponentFactory;
 import com.mygdx.game.server.ecs.entityfactory.SubFieldFactory;
-import com.mygdx.game.server.model.Client;
-import com.mygdx.game.server.network.GameRoomSyncer;
 import lombok.NonNull;
 
 import javax.inject.Inject;
@@ -59,7 +54,7 @@ public class SubfieldMapInitializer {
     this.assets = assets;
   }
 
-  public IntArray initializeSubarea(int fieldId, Client owner) {
+  public IntArray initializeSubarea(int fieldId) {
     var subFields = new IntArray();
     for (Coordinates coordinates : coordinatesList) {
       int entityId = componentFactory.createEntityId();
@@ -67,8 +62,7 @@ public class SubfieldMapInitializer {
       componentFactory.createCoordinateComponent(coordinates, entityId);
       subFieldFactory.createEntity(entityId, assets
               .getGameConfigs()
-              .get(SubFieldConfig.class, random.nextInt(GameConfigs.SUBFIELD_MAX - GameConfigs.SUBFIELD_MIN) + GameConfigs.SUBFIELD_MIN),
-          owner);
+              .get(SubFieldConfig.class, random.nextInt(GameConfigs.SUBFIELD_MAX - GameConfigs.SUBFIELD_MIN) + GameConfigs.SUBFIELD_MIN));
       componentFactory.createSubFieldComponent(fieldId, entityId);
 
       subFields.add(entityId);

--- a/desktop_server/src/com/mygdx/game/server/initialize/TechnologyInitializer.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/TechnologyInitializer.java
@@ -3,11 +3,8 @@ package com.mygdx.game.server.initialize;
 import com.mygdx.game.assets.GameConfigAssets;
 import com.mygdx.game.config.GameConfigs;
 import com.mygdx.game.config.TechnologyConfig;
-import com.mygdx.game.core.ecs.component.Coordinates;
 import com.mygdx.game.server.ecs.entityfactory.ComponentFactory;
-import com.mygdx.game.server.ecs.entityfactory.FieldFactory;
 import com.mygdx.game.server.ecs.entityfactory.TechnologyFactory;
-import com.mygdx.game.server.model.Client;
 import lombok.NonNull;
 
 import javax.inject.Inject;
@@ -31,7 +28,7 @@ public class TechnologyInitializer {
     this.assets = assets;
   }
 
-  public void initializeTechnologies(Client owner) {
+  public void initializeTechnologies() {
     if (initialized) {
       return;
     }
@@ -39,7 +36,7 @@ public class TechnologyInitializer {
     for (int technologyEntityId = GameConfigs.TECHNOLOGY_MIN; technologyEntityId < GameConfigs.TECHNOLOGY_MAX; technologyEntityId++) {
       int entityId = componentFactory.createEntityId();
       var config = assets.getGameConfigs().get(TechnologyConfig.class, technologyEntityId);
-      technologyFactory.createEntity(entityId, config, owner);
+      technologyFactory.createEntity(entityId, config);
     }
   }
 

--- a/desktop_server/src/com/mygdx/game/server/network/Server.java
+++ b/desktop_server/src/com/mygdx/game/server/network/Server.java
@@ -30,7 +30,6 @@ public final class Server {
   private final GameRoom room;
   private final GameRoomSyncer syncer;
 
-
   private final Json json = new Json();
   private HttpServer server;
 
@@ -70,9 +69,9 @@ public final class Server {
         var width = Integer.parseInt(commands[1]);
         var height = Integer.parseInt(commands[2]);
         syncer.beginTransaction();
-        technologyInitializer.initializeTechnologies(client);
-        mapInitializer.initializeMap(width, height, client);
-        unitInitializer.initializeTestUnit(client);
+        technologyInitializer.initializeTechnologies();
+        mapInitializer.initializeMap(width, height);
+        unitInitializer.initializeTestUnit();
         syncer.endTransaction();
         room.getClients().forEach(ws -> {
           var msg = new GameStartedMessage();


### PR DESCRIPTION
Client na razie nie jest potrzebny do niczego, bo synchronizujemy komponenty przez GameRoomSyncer z każdym podpiętym klientem.

Problemem z tą zmianą jest to, że nie będziemy później mogli chyba za bardzo określić "ownera" entity akurat przy tworzeniu, więc będzie problem z wysłaniem konkretnych entity do konkretnego gracza.

Na pewno da się to jakoś napisać inaczej gdy będzie pisany kod do Playerów, więc usuwam to na razie. 