### PR TITLE
91 map generation strategies

### DIFF
--- a/assets/maptype_configs/botbasic.json
+++ b/assets/maptype_configs/botbasic.json
@@ -1,0 +1,6 @@
+{
+  "id": 10,
+  "name": "botbasic",
+  "polishName": "Podstawowa mapa dla bota",
+  "textureName": "basic.png"
+}

--- a/client_core/src/com/mygdx/game/client_core/ecs/entityfactory/EntityFactory.java
+++ b/client_core/src/com/mygdx/game/client_core/ecs/entityfactory/EntityFactory.java
@@ -2,10 +2,10 @@ package com.mygdx.game.client_core.ecs.entityfactory;
 
 import com.artemis.World;
 import com.mygdx.game.assets.GameScreenAssets;
-import com.mygdx.game.config.EntityConfig;
+import com.mygdx.game.config.Config;
 import lombok.NonNull;
 
-public abstract class EntityFactory<T extends EntityConfig> {
+public abstract class EntityFactory<T extends Config> {
 
   protected final World world;
   protected final GameScreenAssets assets;

--- a/client_core/src/com/mygdx/game/client_core/ecs/entityfactory/Setter.java
+++ b/client_core/src/com/mygdx/game/client_core/ecs/entityfactory/Setter.java
@@ -1,9 +1,9 @@
 package com.mygdx.game.client_core.ecs.entityfactory;
 
-import com.mygdx.game.config.EntityConfig;
+import com.mygdx.game.config.Config;
 
 public interface Setter {
-  Result set(EntityConfig config, int entityId);
+  Result set(Config config, int entityId);
 
   enum Result {
     HANDLED, HANDLING_ERROR, REJECTED

--- a/client_core/src/com/mygdx/game/client_core/model/Technologies.java
+++ b/client_core/src/com/mygdx/game/client_core/model/Technologies.java
@@ -26,5 +26,4 @@ public class Technologies {
     return allTechnologies;
   }
 
-
 }

--- a/client_core/src/com/mygdx/game/client_core/network/GameStartService.java
+++ b/client_core/src/com/mygdx/game/client_core/network/GameStartService.java
@@ -16,8 +16,8 @@ public class GameStartService {
     this.socket = socket;
   }
 
-  public void startGame(int width, int height) {
+  public void startGame(int width, int height, int mapType) {
     log.info("start game request sent");
-    socket.send(String.format("start:%d:%d", width, height));
+    socket.send(String.format("start:%d:%d:%d", width, height, mapType));
   }
 }

--- a/core/src/com/mygdx/game/assets/GameConfigAssetPaths.java
+++ b/core/src/com/mygdx/game/assets/GameConfigAssetPaths.java
@@ -7,6 +7,7 @@ public final class GameConfigAssetPaths {
   public static final String UNIT_CONFIG_DIR = ENTITY_CONFIG_DIR + "units/";
   public static final String SUB_FIELD_CONFIG_DIR = ENTITY_CONFIG_DIR + "subfields/";
   public static final String TECHNOLOGY_CONFIG_DIR = ENTITY_CONFIG_DIR + "technologies/";
+  public static final String MAP_TYPE_CONFIG_DIR = ASSETS_PATH + "maptype_configs/";
 
   private GameConfigAssetPaths() {
   }

--- a/core/src/com/mygdx/game/config/Config.java
+++ b/core/src/com/mygdx/game/config/Config.java
@@ -2,7 +2,7 @@ package com.mygdx.game.config;
 
 import lombok.NonNull;
 
-public interface EntityConfig {
+public interface Config {
   @NonNull
-  int getId();
+  long getId();
 }

--- a/core/src/com/mygdx/game/config/FieldConfig.java
+++ b/core/src/com/mygdx/game/config/FieldConfig.java
@@ -8,8 +8,8 @@ import lombok.NonNull;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class FieldConfig implements EntityConfig, ModelConfig {
-  private int id;
+public class FieldConfig implements Config, ModelConfig {
+  private long id;
   @NonNull
   private String name;
   @NonNull

--- a/core/src/com/mygdx/game/config/GameConfigs.java
+++ b/core/src/com/mygdx/game/config/GameConfigs.java
@@ -18,43 +18,55 @@ public class GameConfigs {
   public static final int SUBFIELD_MAX = 8;
   public static final int TECHNOLOGY_MIN = 8;
   public static final int TECHNOLOGY_MAX = 10;
+  public static final int MAP_TYPE_MIN = 10;
+  public static final int MAP_TYPE_MAX = 11;
 
-  private final LongMap<EntityConfig> entityConfigMap = new LongMap<>();
+  private final LongMap<Config> configMap = new LongMap<>();
 
   @Inject
   public GameConfigs() {
     super();
   }
 
-  public <T extends EntityConfig> @NonNull T get(
+  public <T extends Config> @NonNull T get(
       @NonNull final Class<T> entityClass,
       final long entityConfigId
   ) {
-    return entityClass.cast(entityConfigMap.get(entityConfigId));
+    return entityClass.cast(configMap.get(entityConfigId));
   }
 
-  public @NonNull EntityConfig get(long entityConfigId) {
-    return entityConfigMap.get(entityConfigId);
+  public @NonNull Config get(long entityConfigId) {
+    return configMap.get(entityConfigId);
   }
 
-  public <T extends EntityConfig> @NonNull T getAny(@NonNull final Class<T> entityClass) { // don't use later
-    for (var next : entityConfigMap.values()) {
+  public <T extends Config> @NonNull T getAny(@NonNull final Class<T> entityClass) { // don't use later
+    for (var next : configMap.values()) {
       if (entityClass.isInstance(next)) {
         return entityClass.cast(next);
       }
     }
-    throw new IllegalArgumentException("No such EntityConfig saved");
+    throw new IllegalArgumentException("No such Config saved");
+  }
+
+  public <T extends Config> Array<T> getAll(Class<T> configClass) {
+    var array = new Array<T>(false, 16);
+    configMap.values().forEach(config -> {
+      if (configClass.isInstance(config)) {
+        array.add(configClass.cast(config));
+      }
+    });
+    return array;
   }
 
   public int size() {
-    return entityConfigMap.size;
+    return configMap.size;
   }
 
-  public void put(@NonNull final EntityConfig entityConfig) {
-    entityConfigMap.put(entityConfig.getId(), entityConfig);
+  public void put(@NonNull final Config entityConfig) {
+    configMap.put(entityConfig.getId(), entityConfig);
   }
 
-  public <T extends EntityConfig> void putAll(@NonNull final Array<T> entityConfigArray) {
+  public <T extends Config> void putAll(@NonNull final Array<T> entityConfigArray) {
     for (int i = 0; i < entityConfigArray.size; i++) {
       put(entityConfigArray.get(i));
     }

--- a/core/src/com/mygdx/game/config/MapTypeConfig.java
+++ b/core/src/com/mygdx/game/config/MapTypeConfig.java
@@ -3,19 +3,13 @@ package com.mygdx.game.config;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
 @Data
-@NoArgsConstructor
 @AllArgsConstructor
-public class TechnologyConfig implements Config, TextureConfig {
+@NoArgsConstructor
+public class MapTypeConfig implements Config {
   private long id;
-  @NonNull
   private String name;
-  @NonNull
   private String polishName;
-  @NonNull
-  private String textureName;
-  private int x;
-  private int y;
+  private String textureName; // icon
 }

--- a/core/src/com/mygdx/game/config/SubFieldConfig.java
+++ b/core/src/com/mygdx/game/config/SubFieldConfig.java
@@ -8,8 +8,8 @@ import lombok.NonNull;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class SubFieldConfig implements EntityConfig, ModelConfig {
-  private int id;
+public class SubFieldConfig implements Config, ModelConfig {
+  private long id;
   @NonNull
   private String name;
   @NonNull

--- a/core/src/com/mygdx/game/config/UnitConfig.java
+++ b/core/src/com/mygdx/game/config/UnitConfig.java
@@ -8,8 +8,8 @@ import lombok.NonNull;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class UnitConfig implements EntityConfig, ModelConfig {
-  private int id;
+public class UnitConfig implements Config, ModelConfig {
+  private long id;
   @NonNull
   private String name;
   @NonNull

--- a/core/src/com/mygdx/game/core/ecs/component/EntityConfigId.java
+++ b/core/src/com/mygdx/game/core/ecs/component/EntityConfigId.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 public class EntityConfigId extends PooledComponent {
-  private int id;
+  private long id;
 
   @Override
   protected void reset() {

--- a/core/src/com/mygdx/game/core/util/DirtyInt.java
+++ b/core/src/com/mygdx/game/core/util/DirtyInt.java
@@ -1,0 +1,9 @@
+package com.mygdx.game.core.util;
+
+import lombok.Data;
+
+@Data
+public class DirtyInt {
+  private int value = -0xC0FFE;
+  private boolean isDirty = true;
+}

--- a/core/src/com/mygdx/game/core/util/DirtyInt.java
+++ b/core/src/com/mygdx/game/core/util/DirtyInt.java
@@ -1,9 +1,0 @@
-package com.mygdx.game.core.util;
-
-import lombok.Data;
-
-@Data
-public class DirtyInt {
-  private int value = -0xC0FFE;
-  private boolean isDirty = true;
-}

--- a/desktop/src/com/mygdx/game/client/GameFactory.java
+++ b/desktop/src/com/mygdx/game/client/GameFactory.java
@@ -2,6 +2,7 @@ package com.mygdx.game.client;
 
 import com.mygdx.game.client.di.ComponentMessageListenerModule;
 import com.mygdx.game.client.di.NavigatorModule;
+import com.mygdx.game.client.di.SetterBindingsModule;
 import com.mygdx.game.client.di.StageModule;
 import com.mygdx.game.client.di.ViewportModule;
 import com.mygdx.game.client.di.WorldModule;
@@ -19,7 +20,8 @@ import javax.inject.Singleton;
     StageModule.class,
     NetworkModule.class,
     ComponentMessageListenerModule.class,
-    NavigatorModule.class
+    NavigatorModule.class,
+    SetterBindingsModule.class
 })
 public interface GameFactory {
   GdxGame providesGame();

--- a/desktop/src/com/mygdx/game/client/di/SetterBindingsModule.java
+++ b/desktop/src/com/mygdx/game/client/di/SetterBindingsModule.java
@@ -1,0 +1,34 @@
+package com.mygdx.game.client.di;
+
+import com.mygdx.game.client.ecs.entityfactory.ChooseableSetter;
+import com.mygdx.game.client.ecs.entityfactory.DesktopCoordinateSetter;
+import com.mygdx.game.client.ecs.entityfactory.ModelInstanceCompSetter;
+import com.mygdx.game.client.ecs.entityfactory.NavigationDirectionSetter;
+import com.mygdx.game.client.ecs.entityfactory.TextureCompSetter;
+import com.mygdx.game.client_core.ecs.entityfactory.Setter;
+import dagger.Binds;
+import dagger.Module;
+import dagger.multibindings.IntoSet;
+
+@Module
+public interface SetterBindingsModule {
+  @Binds
+  @IntoSet
+  Setter providesChooseableSetter(ChooseableSetter setter);
+
+  @Binds
+  @IntoSet
+  Setter providesDesktopCoordinateSetter(DesktopCoordinateSetter setter);
+
+  @Binds
+  @IntoSet
+  Setter providesModelInstanceCompSetter(ModelInstanceCompSetter setter);
+
+  @Binds
+  @IntoSet
+  Setter providesNavigationDirectionSetter(NavigationDirectionSetter setter);
+
+  @Binds
+  @IntoSet
+  Setter providesTextureCompSetter(TextureCompSetter setter);
+}

--- a/desktop/src/com/mygdx/game/client/ecs/entityfactory/ChooseableSetter.java
+++ b/desktop/src/com/mygdx/game/client/ecs/entityfactory/ChooseableSetter.java
@@ -4,7 +4,7 @@ import com.artemis.ComponentMapper;
 import com.artemis.World;
 import com.mygdx.game.client.ecs.component.Choosable;
 import com.mygdx.game.client_core.ecs.entityfactory.Setter;
-import com.mygdx.game.config.EntityConfig;
+import com.mygdx.game.config.Config;
 import com.mygdx.game.config.FieldConfig;
 import com.mygdx.game.config.UnitConfig;
 import lombok.NonNull;
@@ -23,7 +23,7 @@ public class ChooseableSetter implements Setter {
   }
 
   @Override
-  public Result set(EntityConfig config, int entityId) {
+  public Result set(Config config, int entityId) {
     if (config instanceof FieldConfig || config instanceof UnitConfig) {
       clickableMapper.set(entityId, true);
       return Result.HANDLED;

--- a/desktop/src/com/mygdx/game/client/ecs/entityfactory/DesktopCoordinateSetter.java
+++ b/desktop/src/com/mygdx/game/client/ecs/entityfactory/DesktopCoordinateSetter.java
@@ -3,7 +3,7 @@ package com.mygdx.game.client.ecs.entityfactory;
 import com.artemis.ComponentMapper;
 import com.artemis.World;
 import com.mygdx.game.client_core.ecs.entityfactory.Setter;
-import com.mygdx.game.config.EntityConfig;
+import com.mygdx.game.config.Config;
 import com.mygdx.game.config.TechnologyConfig;
 import com.mygdx.game.core.ecs.component.Coordinates;
 import lombok.NonNull;
@@ -24,7 +24,7 @@ public class DesktopCoordinateSetter implements Setter {
   }
 
   @Override
-  public Result set(EntityConfig config, int entityId) {
+  public Result set(Config config, int entityId) {
     if (config instanceof TechnologyConfig technologyConfig) {
       setUpCoordinateComp(technologyConfig, entityId);
       return Result.HANDLED;

--- a/desktop/src/com/mygdx/game/client/ecs/entityfactory/ModelInstanceCompSetter.java
+++ b/desktop/src/com/mygdx/game/client/ecs/entityfactory/ModelInstanceCompSetter.java
@@ -8,7 +8,7 @@ import com.mygdx.game.assets.GameScreenAssets;
 import com.mygdx.game.client.ecs.component.ModelInstanceComp;
 import com.mygdx.game.client.util.ModelInstanceUtil;
 import com.mygdx.game.client_core.ecs.entityfactory.Setter;
-import com.mygdx.game.config.EntityConfig;
+import com.mygdx.game.config.Config;
 import com.mygdx.game.config.ModelConfig;
 import lombok.NonNull;
 
@@ -22,14 +22,16 @@ public class ModelInstanceCompSetter implements Setter {
   private final GameScreenAssets assets;
 
   @Inject
-  public ModelInstanceCompSetter(@NonNull World world,
-                                 @NonNull GameScreenAssets assets) {
+  public ModelInstanceCompSetter(
+      @NonNull World world,
+      @NonNull GameScreenAssets assets
+  ) {
     this.modelMapper = world.getMapper(ModelInstanceComp.class);
     this.assets = assets;
   }
 
   @Override
-  public Result set(EntityConfig config, int entityId) {
+  public Result set(Config config, int entityId) {
     if (config instanceof ModelConfig modelConfig) {
       setUpModelInstanceComp(modelConfig, entityId);
       return Result.HANDLED;

--- a/desktop/src/com/mygdx/game/client/ecs/entityfactory/NavigationDirectionSetter.java
+++ b/desktop/src/com/mygdx/game/client/ecs/entityfactory/NavigationDirectionSetter.java
@@ -5,7 +5,7 @@ import com.artemis.World;
 import com.mygdx.game.client.ecs.component.NavigationDirection;
 import com.mygdx.game.client.screen.Navigator;
 import com.mygdx.game.client_core.ecs.entityfactory.Setter;
-import com.mygdx.game.config.EntityConfig;
+import com.mygdx.game.config.Config;
 import com.mygdx.game.config.FieldConfig;
 import lombok.NonNull;
 
@@ -21,7 +21,7 @@ public class NavigationDirectionSetter implements Setter {
     this.directionMapper = world.getMapper(NavigationDirection.class);
   }
 
-  public Result set(EntityConfig config, int entity) {
+  public Result set(Config config, int entity) {
     if (config instanceof FieldConfig) {
       directionMapper.create(entity).direction = Navigator.Direction.FIELD_SCREEN;
       return Result.HANDLED;

--- a/desktop/src/com/mygdx/game/client/ecs/entityfactory/TextureCompSetter.java
+++ b/desktop/src/com/mygdx/game/client/ecs/entityfactory/TextureCompSetter.java
@@ -5,7 +5,7 @@ import com.artemis.World;
 import com.mygdx.game.assets.GameScreenAssets;
 import com.mygdx.game.client.ecs.component.TextureComp;
 import com.mygdx.game.client_core.ecs.entityfactory.Setter;
-import com.mygdx.game.config.EntityConfig;
+import com.mygdx.game.config.Config;
 import com.mygdx.game.config.TextureConfig;
 import lombok.NonNull;
 import lombok.extern.java.Log;
@@ -28,7 +28,7 @@ public class TextureCompSetter implements Setter {
   }
 
   @Override
-  public Result set(EntityConfig config, int entityId) {
+  public Result set(Config config, int entityId) {
     if (config instanceof TextureConfig textureConfig) {
       setUpTextureComp(textureConfig, entityId);
       return Result.HANDLED;

--- a/desktop/src/com/mygdx/game/client/network/DesktopEntityConfigHandler.java
+++ b/desktop/src/com/mygdx/game/client/network/DesktopEntityConfigHandler.java
@@ -3,18 +3,12 @@ package com.mygdx.game.client.network;
 import com.artemis.Component;
 import com.github.czyzby.websocket.WebSocket;
 import com.mygdx.game.assets.GameConfigAssets;
-import com.mygdx.game.client.ecs.entityfactory.ChooseableSetter;
-import com.mygdx.game.client.ecs.entityfactory.DesktopCoordinateSetter;
-import com.mygdx.game.client.ecs.entityfactory.ModelInstanceCompSetter;
-import com.mygdx.game.client.ecs.entityfactory.NavigationDirectionSetter;
-import com.mygdx.game.client.ecs.entityfactory.TextureCompSetter;
 import com.mygdx.game.client_core.ecs.entityfactory.Setter;
 import com.mygdx.game.client_core.network.ComponentMessageListener;
 import com.mygdx.game.core.ecs.component.EntityConfigId;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 
 import static com.github.czyzby.websocket.WebSocketListener.FULLY_HANDLED;
 import static com.github.czyzby.websocket.WebSocketListener.NOT_HANDLED;
@@ -24,30 +18,22 @@ import static com.mygdx.game.client_core.ecs.entityfactory.Setter.Result.HANDLIN
 public class DesktopEntityConfigHandler implements ComponentMessageListener.Handler {
 
   private final GameConfigAssets assets;
-  private final List<Setter> setterList = new ArrayList<>();
+  private final Set<Setter> setterSet;
 
   @Inject
   public DesktopEntityConfigHandler(
       GameConfigAssets assets,
-      ModelInstanceCompSetter modelInstanceCompSetter,
-      ChooseableSetter chooseableSetter,
-      NavigationDirectionSetter navigationDirectionSetter,
-      TextureCompSetter textureCompSetter,
-      DesktopCoordinateSetter desktopCoordinateSetter
+      Set<Setter> setterSet
   ) {
     this.assets = assets;
-    this.setterList.add(modelInstanceCompSetter);
-    this.setterList.add(chooseableSetter);
-    this.setterList.add(navigationDirectionSetter);
-    this.setterList.add(textureCompSetter);
-    this.setterList.add(desktopCoordinateSetter);
+    this.setterSet = setterSet;
   }
 
   @Override
   public boolean handle(WebSocket webSocket, int worldEntity, Component component) {
     var entityConfigId = ((EntityConfigId) component).getId();
     var config = assets.getGameConfigs().get(entityConfigId);
-    var setterResults = setterList.stream()
+    var setterResults = setterSet.stream()
         .map(setter -> setter.set(config, worldEntity))
         .toList();
     var anyErrors = setterResults.stream().anyMatch(HANDLING_ERROR::equals);

--- a/desktop/src/com/mygdx/game/client/screen/GameScreen.java
+++ b/desktop/src/com/mygdx/game/client/screen/GameScreen.java
@@ -69,7 +69,7 @@ public class GameScreen extends ScreenAdapter {
   public void show() {
     log.info("GameScreen shown");
     if (!initialized) {
-      roomDialogFactory.createAndShow(() -> gameStartService.startGame(5, 5));
+      roomDialogFactory.createAndShow(() -> gameStartService.startGame(5, 5, 10));
       gameConnectService.connect();
       initialized = true;
     }

--- a/desktop_server/src/com/mygdx/game/server/GameFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/GameFactory.java
@@ -1,6 +1,7 @@
 package com.mygdx.game.server;
 
 import com.mygdx.game.core.di.AssetManagerModule;
+import com.mygdx.game.server.di.GeneratorBindingsModule;
 import com.mygdx.game.server.di.WorldModule;
 import dagger.Component;
 
@@ -9,6 +10,7 @@ import javax.inject.Singleton;
 @Singleton
 @Component(modules = {
     AssetManagerModule.class,
+    GeneratorBindingsModule.class,
     WorldModule.class
 })
 public interface GameFactory {

--- a/desktop_server/src/com/mygdx/game/server/di/GeneratorBindingsModule.java
+++ b/desktop_server/src/com/mygdx/game/server/di/GeneratorBindingsModule.java
@@ -1,0 +1,24 @@
+package com.mygdx.game.server.di;
+
+import com.mygdx.game.server.initialize.generators.BasicSubfieldMapGenerator;
+import com.mygdx.game.server.initialize.generators.BotWinningFieldMapGenerator;
+import com.mygdx.game.server.initialize.generators.MapGenerator;
+import com.mygdx.game.server.initialize.generators.SubfieldMapGenerator;
+import dagger.Binds;
+import dagger.Module;
+import dagger.multibindings.IntoSet;
+
+@Module
+public interface GeneratorBindingsModule {
+  @Binds
+  @IntoSet
+  MapGenerator provideBotWinningFieldMapGenerator(
+      BotWinningFieldMapGenerator generator
+  );
+
+  @Binds
+  @IntoSet
+  SubfieldMapGenerator provideBasicSubfieldMapGenerator(
+      BasicSubfieldMapGenerator generator
+  );
+}

--- a/desktop_server/src/com/mygdx/game/server/di/Names.java
+++ b/desktop_server/src/com/mygdx/game/server/di/Names.java
@@ -1,8 +1,0 @@
-package com.mygdx.game.server.di;
-
-public final class Names {
-  public static final String MAP_GENERATOR_LIST = "Map Generator List";
-  private Names() {
-    super();
-  }
-}

--- a/desktop_server/src/com/mygdx/game/server/di/Names.java
+++ b/desktop_server/src/com/mygdx/game/server/di/Names.java
@@ -1,0 +1,8 @@
+package com.mygdx.game.server.di;
+
+public final class Names {
+  public static final String MAP_GENERATOR_LIST = "Map Generator List";
+  private Names() {
+    super();
+  }
+}

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/ComponentFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/ComponentFactory.java
@@ -2,7 +2,7 @@ package com.mygdx.game.server.ecs.entityfactory;
 
 import com.artemis.ComponentMapper;
 import com.artemis.World;
-import com.mygdx.game.config.EntityConfig;
+import com.mygdx.game.config.Config;
 import com.mygdx.game.core.ecs.component.Coordinates;
 import com.mygdx.game.core.ecs.component.EntityConfigId;
 import com.mygdx.game.core.ecs.component.SubField;
@@ -53,8 +53,8 @@ public class ComponentFactory {
     syncer.sendComponent(subField, entityId);
   }
 
-  public void setUpEntityConfig(@NonNull EntityConfig config, int entityId) {
-    int configId = config.getId();
+  public void setUpEntityConfig(@NonNull Config config, int entityId) {
+    var configId = config.getId();
     var entityConfigIdComponent = entityConfigIdMapper.create(entityId);
     entityConfigIdComponent.setId(configId);
     syncer.sendComponent(entityConfigIdComponent, entityId);

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/EntityFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/EntityFactory.java
@@ -1,9 +1,9 @@
 package com.mygdx.game.server.ecs.entityfactory;
 
-import com.mygdx.game.config.EntityConfig;
+import com.mygdx.game.config.Config;
 import lombok.NonNull;
 
-public interface EntityFactory<T extends EntityConfig> {
+public interface EntityFactory<T extends Config> {
 
   @NonNull void createEntity(int entityId, T entityConfig);
 

--- a/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/FieldFactory.java
+++ b/desktop_server/src/com/mygdx/game/server/ecs/entityfactory/FieldFactory.java
@@ -37,12 +37,12 @@ public class FieldFactory implements EntityFactory<FieldConfig> {
   @Override
   public void createEntity(int entityId, @NonNull FieldConfig config) {
     componentFactory.setUpEntityConfig(config, entityId);
-    setUpField(entityId);
+    setUpField(entityId, config);
   }
 
-  private void setUpField(int entityId) {
+  private void setUpField(int entityId, FieldConfig config) {
     var field = fieldMapper.create(entityId);
-    var subFields = subMapInitializer.initializeSubarea(entityId);
+    var subFields = subMapInitializer.initializeSubarea(entityId, config);
     field.setSubFields(subFields);
     syncer.sendComponent(field, entityId);
   }

--- a/desktop_server/src/com/mygdx/game/server/initialize/MapInitializer.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/MapInitializer.java
@@ -1,68 +1,28 @@
 package com.mygdx.game.server.initialize;
 
-import com.mygdx.game.assets.GameConfigAssets;
-import com.mygdx.game.config.FieldConfig;
-import com.mygdx.game.config.GameConfigs;
-import com.mygdx.game.core.ecs.component.Coordinates;
-import com.mygdx.game.server.ecs.entityfactory.ComponentFactory;
-import com.mygdx.game.server.ecs.entityfactory.FieldFactory;
+import com.mygdx.game.server.initialize.generators.MapGeneratorsContainer;
 import lombok.NonNull;
 
 import javax.inject.Inject;
-import java.util.Random;
 
 public class MapInitializer {
 
-  public static final int INITIAL_WIDTH = 10;
-  public static final int INITIAL_HEIGHT = 10;
-  private static final int WINNING_X = 4;
-  private static final int WINNING_Y = 4;
-  private final FieldFactory fieldFactory;
-  private final ComponentFactory componentFactory;
-  private final GameConfigAssets assets;
-  private final Random random = new Random();
+  private final MapGeneratorsContainer generators;
   private boolean initialized = false; // TODO: 16.06.2022 make it support multiple rooms
 
   @Inject
   public MapInitializer(
-      @NonNull FieldFactory fieldFactory,
-      @NonNull ComponentFactory componentFactory,
-      @NonNull GameConfigAssets assets
+      @NonNull MapGeneratorsContainer generators
   ) {
-    this.fieldFactory = fieldFactory;
-    this.componentFactory = componentFactory;
-    this.assets = assets;
+    this.generators = generators;
   }
 
-  public void initializeMap() {
-    initializeMap(INITIAL_WIDTH, INITIAL_HEIGHT);
-  }
-
-  public void initializeMap(int width, int height) {
+  public void initializeMap(int width, int height, long mapType) {
     if (initialized) {
       return;
-    } else {
-      initialized = true;
     }
-    for (int i = 0; i < width; i++) {
-      for (int j = 0; j < height; j++) {
-        if (i != WINNING_X || j != WINNING_Y) {
-          int entityId = componentFactory.createEntityId();
-          componentFactory.createCoordinateComponent(new Coordinates(i, j), entityId);
-          var config = assets
-              .getGameConfigs()
-              .get(FieldConfig.class, random.nextInt(GameConfigs.FIELD_MIN, GameConfigs.FIELD_MAX));
-          fieldFactory.createEntity(entityId, config);
-        }
-      }
-    }
-    createWinningField();
+    initialized = true;
+    generators.get(mapType).generateMap(width, height);
   }
 
-  private void createWinningField() {
-    var winningConfig = assets.getGameConfigs().get(FieldConfig.class, 5);
-    int entityId = componentFactory.createEntityId();
-    componentFactory.createCoordinateComponent(new Coordinates(4, 4), entityId);
-    fieldFactory.createEntity(entityId, winningConfig);
-  }
 }

--- a/desktop_server/src/com/mygdx/game/server/initialize/StartUnitInitializer.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/StartUnitInitializer.java
@@ -1,7 +1,6 @@
 package com.mygdx.game.server.initialize;
 
 import com.mygdx.game.assets.GameConfigAssets;
-import com.mygdx.game.config.GameConfigs;
 import com.mygdx.game.config.UnitConfig;
 import com.mygdx.game.core.ecs.component.Coordinates;
 import com.mygdx.game.server.ecs.entityfactory.ComponentFactory;
@@ -9,14 +8,12 @@ import com.mygdx.game.server.ecs.entityfactory.UnitFactory;
 import lombok.NonNull;
 
 import javax.inject.Inject;
-import java.util.Random;
 
 public class StartUnitInitializer {
 
   private final UnitFactory unitFactory;
   private final ComponentFactory componentFactory;
   private final GameConfigAssets assets;
-  private final Random random = new Random();
 
   private boolean initialized = false; // TODO: 16.06.2022 make it support multiple rooms
 
@@ -38,7 +35,7 @@ public class StartUnitInitializer {
     }
     int entityId = componentFactory.createEntityId();
     componentFactory.createCoordinateComponent(new Coordinates(0, 0), entityId);
-    var anyConfig = assets.getGameConfigs().get(UnitConfig.class, random.nextInt(GameConfigs.UNIT_MAX - GameConfigs.UNIT_MIN) + GameConfigs.UNIT_MIN);
+    var anyConfig = assets.getGameConfigs().getAny(UnitConfig.class);
     unitFactory.createEntity(entityId, anyConfig);
   }
 }

--- a/desktop_server/src/com/mygdx/game/server/initialize/SubfieldMapInitializer.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/SubfieldMapInitializer.java
@@ -1,73 +1,26 @@
 package com.mygdx.game.server.initialize;
 
 import com.badlogic.gdx.utils.IntArray;
-import com.mygdx.game.assets.GameConfigAssets;
-import com.mygdx.game.config.GameConfigs;
-import com.mygdx.game.config.SubFieldConfig;
-import com.mygdx.game.core.ecs.component.Coordinates;
-import com.mygdx.game.server.ecs.entityfactory.ComponentFactory;
-import com.mygdx.game.server.ecs.entityfactory.SubFieldFactory;
-import lombok.NonNull;
+import com.mygdx.game.config.FieldConfig;
+import com.mygdx.game.server.initialize.generators.SubfieldMapGeneratorsContainer;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.List;
-import java.util.Random;
 
 @Singleton
 public class SubfieldMapInitializer {
 
-  private static final List<Coordinates> coordinatesList = List.of(
-      new Coordinates(2, 0),
-      new Coordinates(1, 1),
-      new Coordinates(3, 1),
-      new Coordinates(0, 2),
-      new Coordinates(2, 2),
-      new Coordinates(4, 2),
-      new Coordinates(1, 3),
-      new Coordinates(3, 3),
-      new Coordinates(0, 4),
-      new Coordinates(2, 4),
-      new Coordinates(4, 4),
-      new Coordinates(1, 5),
-      new Coordinates(3, 5),
-      new Coordinates(0, 6),
-      new Coordinates(2, 6),
-      new Coordinates(4, 6),
-      new Coordinates(1, 7),
-      new Coordinates(3, 7),
-      new Coordinates(2, 8)
-  );
-  private final ComponentFactory componentFactory;
-  private final SubFieldFactory subFieldFactory;
-  private final GameConfigAssets assets;
-  private final Random random = new Random();
+  private final SubfieldMapGeneratorsContainer subfieldMapGeneratorsContainer;
 
   @Inject
   public SubfieldMapInitializer(
-      @NonNull ComponentFactory componentFactory,
-      @NonNull SubFieldFactory subFieldFactory,
-      @NonNull GameConfigAssets assets
+      SubfieldMapGeneratorsContainer subfieldMapGeneratorsContainer
   ) {
-    this.componentFactory = componentFactory;
-    this.subFieldFactory = subFieldFactory;
-    this.assets = assets;
+    this.subfieldMapGeneratorsContainer = subfieldMapGeneratorsContainer;
   }
 
-  public IntArray initializeSubarea(int fieldId) {
-    var subFields = new IntArray();
-    for (Coordinates coordinates : coordinatesList) {
-      int entityId = componentFactory.createEntityId();
-
-      componentFactory.createCoordinateComponent(coordinates, entityId);
-      subFieldFactory.createEntity(entityId, assets
-              .getGameConfigs()
-              .get(SubFieldConfig.class, random.nextInt(GameConfigs.SUBFIELD_MAX - GameConfigs.SUBFIELD_MIN) + GameConfigs.SUBFIELD_MIN));
-      componentFactory.createSubFieldComponent(fieldId, entityId);
-
-      subFields.add(entityId);
-    }
-    return subFields;
+  public IntArray initializeSubarea(int fieldId, FieldConfig config) {
+    return subfieldMapGeneratorsContainer.get(config.getId()).generateSubfield(fieldId);
   }
 
 }

--- a/desktop_server/src/com/mygdx/game/server/initialize/TechnologyInitializer.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/TechnologyInitializer.java
@@ -1,7 +1,6 @@
 package com.mygdx.game.server.initialize;
 
 import com.mygdx.game.assets.GameConfigAssets;
-import com.mygdx.game.config.GameConfigs;
 import com.mygdx.game.config.TechnologyConfig;
 import com.mygdx.game.server.ecs.entityfactory.ComponentFactory;
 import com.mygdx.game.server.ecs.entityfactory.TechnologyFactory;
@@ -33,9 +32,9 @@ public class TechnologyInitializer {
       return;
     }
     initialized = true;
-    for (int technologyEntityId = GameConfigs.TECHNOLOGY_MIN; technologyEntityId < GameConfigs.TECHNOLOGY_MAX; technologyEntityId++) {
+    var technologyConfigs = assets.getGameConfigs().getAll(TechnologyConfig.class);
+    for (var config : technologyConfigs) {
       int entityId = componentFactory.createEntityId();
-      var config = assets.getGameConfigs().get(TechnologyConfig.class, technologyEntityId);
       technologyFactory.createEntity(entityId, config);
     }
   }

--- a/desktop_server/src/com/mygdx/game/server/initialize/generators/BasicSubfieldMapGenerator.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/generators/BasicSubfieldMapGenerator.java
@@ -1,0 +1,45 @@
+package com.mygdx.game.server.initialize.generators;
+
+import com.badlogic.gdx.utils.IntArray;
+import com.mygdx.game.assets.GameConfigAssets;
+import com.mygdx.game.config.SubFieldConfig;
+import com.mygdx.game.core.ecs.component.Coordinates;
+import com.mygdx.game.server.ecs.entityfactory.ComponentFactory;
+import com.mygdx.game.server.ecs.entityfactory.SubFieldFactory;
+import lombok.NonNull;
+
+import javax.inject.Inject;
+
+public class BasicSubfieldMapGenerator extends SubfieldMapGenerator {
+
+  private final ComponentFactory componentFactory;
+  private final SubFieldFactory subFieldFactory;
+  private final GameConfigAssets assets;
+
+  @Inject
+  protected BasicSubfieldMapGenerator(
+      @NonNull ComponentFactory componentFactory,
+      @NonNull SubFieldFactory subFieldFactory,
+      @NonNull GameConfigAssets assets) {
+    super(0);
+    this.componentFactory = componentFactory;
+    this.subFieldFactory = subFieldFactory;
+    this.assets = assets;
+  }
+
+  @Override
+  public IntArray generateSubfield(int parentId) {
+    var subFields = new IntArray();
+    for (Coordinates coordinates : coordinatesList) {
+      var subfieldConfig = assets.getGameConfigs().getAny(SubFieldConfig.class);
+
+      var entityId = componentFactory.createEntityId();
+      componentFactory.createCoordinateComponent(coordinates, entityId);
+      subFieldFactory.createEntity(entityId, subfieldConfig);
+      componentFactory.createSubFieldComponent(parentId, entityId);
+
+      subFields.add(entityId);
+    }
+    return subFields;
+  }
+}

--- a/desktop_server/src/com/mygdx/game/server/initialize/generators/BotWinningFieldMapGenerator.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/generators/BotWinningFieldMapGenerator.java
@@ -1,0 +1,61 @@
+package com.mygdx.game.server.initialize.generators;
+
+import com.mygdx.game.config.FieldConfig;
+import com.mygdx.game.config.GameConfigs;
+import com.mygdx.game.core.ecs.component.Coordinates;
+import com.mygdx.game.server.ecs.entityfactory.ComponentFactory;
+import com.mygdx.game.server.ecs.entityfactory.FieldFactory;
+
+import javax.inject.Inject;
+import java.util.Random;
+
+public class BotWinningFieldMapGenerator extends MapGenerator {
+
+  private static final int WINNING_X = 4;
+  private static final int WINNING_Y = 4;
+  private final GameConfigs assets;
+  private final FieldFactory fieldFactory;
+  private final ComponentFactory componentFactory;
+  private final Random random = new Random(0);
+
+  @Inject
+  public BotWinningFieldMapGenerator(
+      GameConfigs assets,
+      FieldFactory fieldFactory,
+      ComponentFactory componentFactory
+  ) {
+    super(10);
+    this.assets = assets;
+    this.fieldFactory = fieldFactory;
+    this.componentFactory = componentFactory;
+  }
+
+  @Override
+  public void generateMap(int width, int height) {
+    for (int i = 0; i < width; i++) {
+      for (int j = 0; j < height; j++) {
+        if (i == WINNING_X && j == WINNING_Y) {
+          continue;
+        }
+        var entityId = componentFactory.createEntityId();
+        componentFactory.createCoordinateComponent(new Coordinates(i, j), entityId);
+        var fieldConfig = chooseFieldConfig();
+        fieldFactory.createEntity(entityId, fieldConfig);
+      }
+    }
+    createWinningField();
+  }
+
+  private FieldConfig chooseFieldConfig() {
+    var fieldConfigs = assets.getAll(FieldConfig.class);
+    var chosenField = random.nextInt(fieldConfigs.size);
+    return fieldConfigs.get(chosenField);
+  }
+
+  private void createWinningField() {
+    var winningConfig = assets.get(FieldConfig.class, 5);
+    int entityId = componentFactory.createEntityId();
+    componentFactory.createCoordinateComponent(new Coordinates(4, 4), entityId);
+    fieldFactory.createEntity(entityId, winningConfig);
+  }
+}

--- a/desktop_server/src/com/mygdx/game/server/initialize/generators/MapGenerator.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/generators/MapGenerator.java
@@ -1,8 +1,11 @@
 package com.mygdx.game.server.initialize.generators;
 
 
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
+@Getter
+@EqualsAndHashCode
 public abstract class MapGenerator {
 
   private final int id;
@@ -13,24 +16,4 @@ public abstract class MapGenerator {
 
   public abstract void generateMap(int width, int height);
 
-  public int getId() {
-    return id;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    var that = (MapGenerator) o;
-    return id == that.id;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(id);
-  }
 }

--- a/desktop_server/src/com/mygdx/game/server/initialize/generators/MapGenerator.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/generators/MapGenerator.java
@@ -1,0 +1,36 @@
+package com.mygdx.game.server.initialize.generators;
+
+
+import java.util.Objects;
+
+public abstract class MapGenerator {
+
+  private final int id;
+
+  protected MapGenerator(int id) {
+    this.id = id;
+  }
+
+  public abstract void generateMap(int width, int height);
+
+  public int getId() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    var that = (MapGenerator) o;
+    return id == that.id;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/desktop_server/src/com/mygdx/game/server/initialize/generators/MapGeneratorsContainer.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/generators/MapGeneratorsContainer.java
@@ -1,0 +1,32 @@
+package com.mygdx.game.server.initialize.generators;
+
+import com.badlogic.gdx.utils.LongMap;
+import lombok.NonNull;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Set;
+
+
+@Singleton
+public class MapGeneratorsContainer {
+  private final LongMap<MapGenerator> mapTypes = new LongMap<>();
+
+  @Inject
+  public MapGeneratorsContainer(
+      Set<MapGenerator> mapGeneratorSet
+  ) {
+    mapGeneratorSet.forEach(gen -> {
+      if (!mapTypes.containsKey(gen.getId())) {
+        mapTypes.put(gen.getId(), gen);
+      } else {
+        throw new IllegalArgumentException("map generators can't have the same id");
+      }
+    });
+  }
+
+  @NonNull
+  public MapGenerator get(long type) {
+    return mapTypes.get(type);
+  }
+}

--- a/desktop_server/src/com/mygdx/game/server/initialize/generators/SubfieldMapGenerator.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/generators/SubfieldMapGenerator.java
@@ -1,0 +1,63 @@
+package com.mygdx.game.server.initialize.generators;
+
+import com.badlogic.gdx.utils.IntArray;
+import com.mygdx.game.core.ecs.component.Coordinates;
+
+import java.util.List;
+import java.util.Objects;
+
+public abstract class SubfieldMapGenerator {
+
+  protected static final List<Coordinates> coordinatesList =
+      List.of(
+          new Coordinates(2, 0),
+          new Coordinates(1, 1),
+          new Coordinates(3, 1),
+          new Coordinates(0, 2),
+          new Coordinates(2, 2),
+          new Coordinates(4, 2),
+          new Coordinates(1, 3),
+          new Coordinates(3, 3),
+          new Coordinates(0, 4),
+          new Coordinates(2, 4),
+          new Coordinates(4, 4),
+          new Coordinates(1, 5),
+          new Coordinates(3, 5),
+          new Coordinates(0, 6),
+          new Coordinates(2, 6),
+          new Coordinates(4, 6),
+          new Coordinates(1, 7),
+          new Coordinates(3, 7),
+          new Coordinates(2, 8)
+      );
+
+  private final int id;
+
+  protected SubfieldMapGenerator(int id) {
+    this.id = id;
+  }
+
+  public abstract IntArray generateSubfield(int parentId);
+
+  public int getId() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SubfieldMapGenerator that = (SubfieldMapGenerator) o;
+    return id == that.id;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+}

--- a/desktop_server/src/com/mygdx/game/server/initialize/generators/SubfieldMapGeneratorsContainer.java
+++ b/desktop_server/src/com/mygdx/game/server/initialize/generators/SubfieldMapGeneratorsContainer.java
@@ -1,0 +1,32 @@
+package com.mygdx.game.server.initialize.generators;
+
+import com.badlogic.gdx.utils.LongMap;
+import lombok.NonNull;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Set;
+
+
+@Singleton
+public class SubfieldMapGeneratorsContainer {
+  private final LongMap<SubfieldMapGenerator> mapTypes = new LongMap<>();
+
+  @Inject
+  public SubfieldMapGeneratorsContainer(
+      Set<SubfieldMapGenerator> subfieldMapGeneratorSet
+  ) {
+    subfieldMapGeneratorSet.forEach(gen -> {
+      if (!mapTypes.containsKey(gen.getId())) {
+        mapTypes.put(gen.getId(), gen);
+      } else {
+        throw new IllegalArgumentException("subfield map generators can't have the same id");
+      }
+    });
+  }
+
+  @NonNull
+  public SubfieldMapGenerator get(long type) {
+    return mapTypes.get(0); // todo prepare other subfield generation strategies for different fields
+  }
+}

--- a/desktop_server/src/com/mygdx/game/server/network/Server.java
+++ b/desktop_server/src/com/mygdx/game/server/network/Server.java
@@ -68,9 +68,10 @@ public final class Server {
       case "start" -> {
         var width = Integer.parseInt(commands[1]);
         var height = Integer.parseInt(commands[2]);
+        var mapType = Long.parseLong(commands[3]);
         syncer.beginTransaction();
         technologyInitializer.initializeTechnologies();
-        mapInitializer.initializeMap(width, height);
+        mapInitializer.initializeMap(width, height, mapType);
         unitInitializer.initializeTestUnit();
         syncer.endTransaction();
         room.getClients().forEach(ws -> {


### PR DESCRIPTION
#91 

Zrobiłem kod, który wydziela generowanie mapy i subfiedla dla danego typu pola. Teraz klient może powiedzieć, że chce mapę typu "10" i serwer będzie generował na podstawie tej liczby mapę. A subfieldy wewnątrz każdego pola są generowane na podstawie rodzaju nadpola. Czyli można zrobić, żeby subfieldy pustyni miały inaczej generowane pola niż subfieldy np pola rzeki.

W chwili obecnej implementacja wymaga, żeby każdy rodzaj pola miał swój generator subfieldów. Trzeba doimplementować dla każdego sposób działania, albo znaleźć jakieś kolejne, ogólne podejście. Na razie jest pełna dowolność. 

Nie ma w kodzie połączenia między takim generatorem o id 10, a plikiem zasobów json, w którym są zapisane dane typu nazwa, ikona i właśnie to id 10. To jest trochę złe, ale nie mam na razie pomysłu czy da się to łatwo połączyć. Te dane z pliku json mogą służyć do stworzenia GUI z wyborem dla gracza.


Właśnie nie ma jeszcze GUI, które byłoby w stanie takie coś obsłużyć, ale z ręki kod żąda właśnie 10-tki. Na GUI jest kolejny issue.